### PR TITLE
A more semantic way of defining settings for build types

### DIFF
--- a/lib/teamcity/client/build_types.rb
+++ b/lib/teamcity/client/build_types.rb
@@ -197,6 +197,23 @@ module TeamCity
         end
       end
 
+      # Set buildtype settings
+      #
+      # @example Cleaning all files between the builds
+      #   TeamCity.set_buildtype_setting('bt3', 'cleanBuild', 'true')
+      # @example Checkout on the server
+      #   TeamCity.set_buildtype_setting('bt3', 'checkoutMode', 'ON_SERVER')
+      # @example Fail the build after 10 Minutes
+      #   Teamcity.set_buildtype_setting('bt3', 'executionTimeoutMin', '10')
+      #
+      # @param buidltype_id [String] the buildtype id
+      # @param setting_name [String] the settings name
+      # @param setting_value [String] the value to set the settings to
+      # @return setting_value [String] value that was set
+      def set_buildtype_setting(buildtype_id, setting_name, setting_value)
+        set_buildtype_field(buildtype_id, "settings/#{setting_name}", setting_value)
+      end
+
       # Delete buildtype (build configuration)
       #
       # @param buildtype_id [String] the id of the buildtype

--- a/spec/cassettes/BuildTypes/PUT/_set_buildtype_setting/should_set_if_it_should_perform_clean_builds.yml
+++ b/spec/cassettes/BuildTypes/PUT/_set_buildtype_setting/should_set_if_it_should_perform_clean_builds.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://teamcity-ruby-client:teamcity@localhost:8111/httpAuth/app/rest/buildTypes/BuildTypeTests_PutSetBuildTypeSettings/settings/cleanBuild
+    body:
+      encoding: UTF-8
+      string: 'true'
+    headers:
+      User-Agent:
+      - TeamCity Ruby Client 1.1.0
+      Accept:
+      - text/plain
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - RememberMe=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly
+      - TCSESSIONID=1D99A32BD61552E930964F603B52EBC8; Path=/; HttpOnly
+      Pragma:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      - no-store
+      Content-Type:
+      - text/plain
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 19 Nov 2013 15:50:59 GMT
+    body:
+      encoding: UTF-8
+      string: 'true'
+    http_version: 
+  recorded_at: Tue, 19 Nov 2013 15:50:59 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/BuildTypes/PUT/_set_buildtype_setting/should_set_what_is_the_timeout_in_minutes_when_executing_builds.yml
+++ b/spec/cassettes/BuildTypes/PUT/_set_buildtype_setting/should_set_what_is_the_timeout_in_minutes_when_executing_builds.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://teamcity-ruby-client:teamcity@localhost:8111/httpAuth/app/rest/buildTypes/BuildTypeTests_PutSetBuildTypeSettings/settings/executionTimeoutMin
+    body:
+      encoding: UTF-8
+      string: '10'
+    headers:
+      User-Agent:
+      - TeamCity Ruby Client 1.1.0
+      Accept:
+      - text/plain
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - RememberMe=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly
+      - TCSESSIONID=4FE4C7EC997C6647CFB8D72A8A4D27C3; Path=/; HttpOnly
+      Pragma:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      - no-store
+      Content-Type:
+      - text/plain
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 19 Nov 2013 15:50:59 GMT
+    body:
+      encoding: UTF-8
+      string: '10'
+    http_version: 
+  recorded_at: Tue, 19 Nov 2013 15:50:59 GMT
+recorded_with: VCR 2.4.0

--- a/spec/cassettes/BuildTypes/PUT/_set_buildtype_setting/should_set_where_the_checkout_happens_when_building.yml
+++ b/spec/cassettes/BuildTypes/PUT/_set_buildtype_setting/should_set_where_the_checkout_happens_when_building.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: http://teamcity-ruby-client:teamcity@localhost:8111/httpAuth/app/rest/buildTypes/BuildTypeTests_PutSetBuildTypeSettings/settings/checkoutMode
+    body:
+      encoding: UTF-8
+      string: ON_AGENT
+    headers:
+      User-Agent:
+      - TeamCity Ruby Client 1.1.0
+      Accept:
+      - text/plain
+      Content-Type:
+      - text/plain
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - RememberMe=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; HttpOnly
+      - TCSESSIONID=D54F4E6C1DAEAD64AFF4347E800034BD; Path=/; HttpOnly
+      Pragma:
+      - no-cache
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Cache-Control:
+      - no-cache
+      - no-store
+      Content-Type:
+      - text/plain
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Tue, 19 Nov 2013 15:50:59 GMT
+    body:
+      encoding: UTF-8
+      string: ON_AGENT
+    http_version: 
+  recorded_at: Tue, 19 Nov 2013 15:50:59 GMT
+recorded_with: VCR 2.4.0

--- a/spec/teamcity/client/buildtypes_spec.rb
+++ b/spec/teamcity/client/buildtypes_spec.rb
@@ -138,7 +138,6 @@ describe 'BuildTypes' do
     end
 
     describe '.set_buildtype_field' do
-
       before(:each) do
         @buildtype_id = 'BuildTypeTests_PutSetBuildTypeField'
       end
@@ -159,6 +158,30 @@ describe 'BuildTypes' do
         field_name = 'paused'
         field_value = 'true'
         @tc.set_buildtype_field(@buildtype_id, field_name, field_value).should eq(field_value)
+      end
+    end
+
+    describe '.set_buildtype_setting' do
+      before(:each) do
+        @buildtype_id = 'BuildTypeTests_PutSetBuildTypeSettings'
+      end
+
+      it 'should set if it should perform clean builds' do
+        settings_name = 'cleanBuild'
+        settings_value = 'true'
+        @tc.set_buildtype_setting(@buildtype_id, settings_name, settings_value).should eq(settings_value)
+      end
+
+      it 'should set where the checkout happens when building' do
+        settings_name = 'checkoutMode'
+        settings_value = 'ON_AGENT'
+        @tc.set_buildtype_setting(@buildtype_id, settings_name, settings_value).should eq(settings_value)
+      end
+
+      it 'should set what is the timeout in minutes when executing builds' do
+        settings_name = 'executionTimeoutMin'
+        settings_value = '10'
+        @tc.set_buildtype_setting(@buildtype_id, settings_name, settings_value).should eq(settings_value)
       end
     end
 


### PR DESCRIPTION
A simple alias for set_buildtype_field method. More of the same but I think it's worth having it as a separated method to avoid repeating "/settings" as a namespace in the calls. Thoughts?
